### PR TITLE
Faster Auditing::Request#initialize

### DIFF
--- a/lib/auditing/request.rb
+++ b/lib/auditing/request.rb
@@ -25,6 +25,8 @@ module Auditing
     end
 
     def params=(params)
+      # replace_params is *really* slow when given huge requests.
+      # Lazily call that method when needed to combat this.
       @raw_params = params
     end
 
@@ -33,7 +35,7 @@ module Auditing
         @params = replace_params(@raw_params)
         @raw_params = nil
       end
-      super
+      @params
     end
 
     def self.find_by_url(url, partial = false)

--- a/lib/auditing/request.rb
+++ b/lib/auditing/request.rb
@@ -25,7 +25,15 @@ module Auditing
     end
 
     def params=(params)
-      @params = self.replace_params(params)
+      @raw_params = params
+    end
+
+    def params
+      if @raw_params
+        @params = replace_params(@raw_params)
+        @raw_params = nil
+      end
+      super
     end
 
     def self.find_by_url(url, partial = false)


### PR DESCRIPTION
Initializing an auditing request will always call `replace_params` with the request params, which recursively fixes some ruby types. Given a request with a huge amount of parameters, this is stupidly slow.

This PR delays this slow operation until you actually call `#params`, which might never happen.

I've seen savings of >1s when fetching a whole bunch of requests from mongo in a single batch, and pumping that data into `Auditing::Request#initialize`.